### PR TITLE
Eventually consistent -- sleep after write

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -13,6 +13,7 @@ https://discourse.charmhub.io/t/4208
 """
 
 import logging
+import time
 
 import ops
 from ops import ActiveStatus, SecretNotFoundError
@@ -105,11 +106,13 @@ class SecretsTestCharm(ops.CharmBase):
             content.update({key: value})
             logger.info(f"Setting secret {secret.id} to {content}")
             secret.set_content(content)
+            time.sleep(10)
         else:
             content = {
                 key: value,
             }
             secret = self.app.add_secret(content)
+            time.sleep(10)
             self.app_peer_data["secret-id"] = secret.id
             logger.info(f"Added secret {secret.id} to {content}")
 
@@ -130,6 +133,7 @@ class SecretsTestCharm(ops.CharmBase):
         logger.info(f"Remaining content is {list(content.keys())}")
         if content:
             secret.set_content(content)
+            time.sleep(10)
         else:
             secret.remove_all_revisions()
             del self.app_peer_data["secret-id"]


### PR DESCRIPTION
Perhaps due to mongodb stale reads a `sleep(10)` on each write may result in expected behavior.